### PR TITLE
docs: clarify generator features and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A small collection of Roslyn source generators.
 
+Each generator ships as two NuGet packages: the generator itself and a companion
+`*.Attributes` package containing only the attributes. Reference both packages
+to run the generator, or reference just the attributes package when you merely
+want the annotations available without executing the generator.
+
 ## Generators
 
 | Generator | Description |

--- a/src/MBW.Generators.NonTryMethods/README.md
+++ b/src/MBW.Generators.NonTryMethods/README.md
@@ -8,7 +8,7 @@ Picture a repository with a `TryFind` method that returns a `bool` and an `out` 
 ## Quick Start
 - Install the `MBW.Generators.NonTryMethods` and `MBW.Generators.NonTryMethods.Attributes` packages.
 - Add `[GenerateNonTryMethod]` (and optionally `[GenerateNonTryOptions]`) at the assembly or type level.
-- By default, methods matching the regex `^[Tt]ry(.*)` with a `bool` return and an `out` parameter are wrapped. Generated methods return the `out` value or throw `InvalidOperationException`, and the generator automatically chooses between partial methods and extensions.
+- By default, methods matching the regex `^[Tt]ry(.*)` with a `bool` return and an `out` parameter are wrapped. Generated methods return the `out` value or throw `InvalidOperationException`. Generated members are emitted into partial types; set `MethodsGenerationStrategy.Extensions` to produce extension methods instead.
 
 Attributes and generator are in separate packages so you can reference the attributes without running the generator.
 
@@ -50,7 +50,8 @@ partial class Repository
 - Customize the exception thrown when a method fails.
 - Supports synchronous and asynchronous wrappers.
 - Uses incremental generators for performance.
-- Emits diagnostics to guide correct usage.
+- Emits diagnostics to guide correct usage, including invalid regex patterns, duplicate signatures, and collisions with existing members.
+- Generated methods include XML documentation that references the source method.
 - Generates partial members, extensions, and interface implementations with default bodies.
 - Preserves visibility and parameter names from the source methods.
 
@@ -66,7 +67,7 @@ partial class Repository
     - `Verbatim` – copy the `out` parameter's nullability.
     - `TrueMeansNotNull` – successful calls are assumed to return non-null.
   - `MethodsGenerationStrategy` – where to place generated methods:
-    - `Auto` – generator decides between partial types or extensions.
+    - `Auto` – emit into partial types (default).
     - `PartialType` – emit into partial types (requires partial declaration).
     - `Extensions` – emit extension methods.
 

--- a/src/MBW.Generators.OverloadGenerator/README.md
+++ b/src/MBW.Generators.OverloadGenerator/README.md
@@ -8,7 +8,7 @@ Imagine an API that accepts a string kind and an optional retry flag. Callers mi
 ## Quick Start
 - Install the `MBW.Generators.OverloadGenerator` and `MBW.Generators.OverloadGenerator.Attributes` packages.
 - Decorate your partial class or individual methods with `[TransformOverload]` or `[DefaultOverload]`.
-- The generator emits overloads for decorated methods, preserving visibility and parameter names and keeping extension methods as extensions.
+- The generator emits overloads for decorated methods, preserving visibility, parameter names, generic constraints, and default parameter values while keeping extension methods as extensions.
 
 Attributes and generator are in separate packages so you can reference the attributes without running the generator.
 
@@ -44,22 +44,24 @@ partial class Orders
 ## Features
 - Replace parameters with strongly typed alternatives or supply defaults.
 - Apply attributes at type or method level for flexible targeting.
-- Supports extension methods and generic types.
+- Supports extension methods and generic types, preserving generic constraints and default parameter values.
 - Uses incremental generators for performance.
-- Emits diagnostics to help guide usage.
+- Emits diagnostics to help guide usage, including signature collisions, missing parameters, invalid `accept` types, missing `{value}` tokens, and attempts to remove the `this` receiver of an extension method.
 - Preserves original method visibility and parameter names.
 - Generates interface members with default bodies where applicable.
 
 ## Attributes
 - **TransformOverloadAttribute** – apply to a type or method. Replaces a string parameter with a strongly typed version. Parameters:
   - `parameter` – the name of the parameter to replace.
-  - `accept` – the type callers can supply.
+  - `accept` – the type callers can supply. Unsupported types produce a diagnostic.
   - `transform` – an expression where `{value}` is substituted with the parameter.
   - `Usings` – optional namespaces added to the generated file.
 - **DefaultOverloadAttribute** – apply to a type or method. Emits an overload that supplies a default expression when the specified parameter is omitted. Parameters:
   - `parameter` – the name of the parameter to default.
   - `defaultExpression` – expression inserted for the missing argument.
   - `Usings` – optional namespaces added to the generated file.
+
+Removing the `this` receiver of an extension method is not supported and will trigger a diagnostic.
 
 Both attributes may appear multiple times and are not inherited.
 


### PR DESCRIPTION
## Summary
- explain that generators ship with separate attributes packages
- clarify default generation strategy for non-try methods and document diagnostics
- document overload generator's constraint preservation and diagnostic behaviors

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a0329e62188331bb568944bf9f6ea4