### PR TITLE
Use GeneratorHelpers for symbol name checks

### DIFF
--- a/_Imports/SourceGenerator.targets
+++ b/_Imports/SourceGenerator.targets
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all"/>
+    <PackageReference Include="MBW.Generators.GeneratorHelpers" Version="0.3.0" PrivateAssets="all"/>
   </ItemGroup>
 
   <Choose>

--- a/src/Generators/OverloadGenerator.Generator/Models/AttributesCollection.cs
+++ b/src/Generators/OverloadGenerator.Generator/Models/AttributesCollection.cs
@@ -9,18 +9,14 @@ internal readonly record struct AttributesCollection(
     ImmutableArray<DefaultOverloadAttributeInfoWithRegex> DefaultAttributes,
     ImmutableArray<TransformOverloadAttributeInfoWithRegex> TransformAttributes)
 {
-    public static AttributesCollection From(KnownSymbols? knownSymbols, ISymbol symbol)
+    public static AttributesCollection From(ISymbol symbol)
     {
-        if (knownSymbols is null)
-            return new AttributesCollection(ImmutableArray<DefaultOverloadAttributeInfoWithRegex>.Empty,
-                ImmutableArray<TransformOverloadAttributeInfoWithRegex>.Empty);
-
         List<DefaultOverloadAttributeInfoWithRegex>? defaults = null;
         List<TransformOverloadAttributeInfoWithRegex>? transforms = null;
 
         foreach (AttributeData attr in symbol.GetAttributes())
         {
-            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownSymbols.DefaultOverloadAttribute))
+            if (attr.AttributeClass.IsNamedExactlyTypeDefaultOverloadAttribute())
             {
                 var info = AttributeConverters.ToDefault(attr);
                 if (AttributeValidation.IsValidRegexPattern(info.ParameterNamePattern, out var paramRegex) &&
@@ -30,7 +26,7 @@ internal readonly record struct AttributesCollection(
                     defaults.Add(new DefaultOverloadAttributeInfoWithRegex(info, paramRegex, methodRegex));
                 }
             }
-            else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownSymbols.TransformOverloadAttribute))
+            else if (attr.AttributeClass.IsNamedExactlyTypeTransformOverloadAttribute())
             {
                 var info = AttributeConverters.ToTransform(attr);
                 if (AttributeValidation.IsValidRegexPattern(info.ParameterNamePattern, out var paramRegex) &&

--- a/src/Generators/OverloadGenerator.Generator/Models/KnownSymbols.cs
+++ b/src/Generators/OverloadGenerator.Generator/Models/KnownSymbols.cs
@@ -1,32 +1,14 @@
-using Microsoft.CodeAnalysis;
+using MBW.Generators.GeneratorHelpers;
+using MBW.Generators.GeneratorHelpers.Attributes;
 
 namespace MBW.Generators.OverloadGenerator.Generator.Models;
 
-internal sealed class KnownSymbols
+[GenerateSymbolExtensions]
+internal static partial class KnownSymbols
 {
-    public const string DefaultOverloadAttributeName = "MBW.Generators.OverloadGenerator.Attributes.DefaultOverloadAttribute";
-    public const string TransformOverloadAttributeName = "MBW.Generators.OverloadGenerator.Attributes.TransformOverloadAttribute";
+    [SymbolNameExtension]
+    public const string DefaultOverloadAttribute = "MBW.Generators.OverloadGenerator.Attributes.DefaultOverloadAttribute";
 
-    public readonly INamedTypeSymbol DefaultOverloadAttribute;
-    public readonly INamedTypeSymbol TransformOverloadAttribute;
-
-    private KnownSymbols(INamedTypeSymbol defaultOverloadAttribute, INamedTypeSymbol transformOverloadAttribute)
-    {
-        DefaultOverloadAttribute = defaultOverloadAttribute;
-        TransformOverloadAttribute = transformOverloadAttribute;
-    }
-
-    public static KnownSymbols? TryCreateInstance(Compilation compilation)
-    {
-        var defaultAttribute =
-            compilation.GetTypeByMetadataName(DefaultOverloadAttributeName);
-        var transformAttribute =
-            compilation.GetTypeByMetadataName(
-                TransformOverloadAttributeName);
-
-        if (defaultAttribute == null || transformAttribute == null)
-            return null;
-
-        return new KnownSymbols(defaultAttribute, transformAttribute);
-    }
+    [SymbolNameExtension]
+    public const string TransformOverloadAttribute = "MBW.Generators.OverloadGenerator.Attributes.TransformOverloadAttribute";
 }


### PR DESCRIPTION
## Summary
- use GeneratorHelpers package in generators
- compare overload attributes using generated symbol-name extensions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba99299ce48331b0a60516567368b5